### PR TITLE
[WIP] Improve release tools

### DIFF
--- a/pyfarm/__init__.py
+++ b/pyfarm/__init__.py
@@ -1,0 +1,17 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__import__("pkg_resources").declare_namespace(__name__)

--- a/pyfarm/release/__init__.py
+++ b/pyfarm/release/__init__.py
@@ -1,0 +1,22 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Release
+=======
+
+Module responsible for building releases of PyFarm's modules.
+"""

--- a/pyfarm/release/entrypoints.py
+++ b/pyfarm/release/entrypoints.py
@@ -115,6 +115,9 @@ def release():
     create_tag(args.setup_py, release_version, dry_run=args.dry_run)
     release_to_pypi(args.setup_py, dry_run=args.dry_run)
 
+    # TODO: create release on github
+    # TODO: add sdist file to release on github
+    # TODO: populate release on github with all issues/PRs assoicated with it
 
 
 

--- a/pyfarm/release/entrypoints.py
+++ b/pyfarm/release/entrypoints.py
@@ -1,0 +1,121 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Release
+=======
+
+Produces a release of the current project.
+"""
+
+from __future__ import print_function
+
+from argparse import ArgumentParser
+from os.path import isfile, abspath, dirname
+
+from pyfarm.release.parse_setup import get_setup_keyword_value
+from pyfarm.release.remote import latest_pypi_release, remote_tag_exists
+from pyfarm.release.git import local_tag_exists, create_tag
+from pyfarm.release.utility import check_call
+
+try:
+    input_ = raw_input
+except NameError:
+    input_ = input
+
+
+
+def release_to_pypi(setup_py, dry_run=True):
+    print("Producing PyPi release using %s" % setup_py)
+    check_call(
+        ["python", "setup.py", "sdist", "upload"],
+        dry_run=dry_run,
+        cwd=dirname(setup_py)
+    )
+
+def release():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--setup-py", default="setup.py",
+        help="The location of the setup.py file (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", default=False,
+        help="When provided, do not create a release."
+    )
+    parser.add_argument(
+        "version", nargs="?",
+        help="The version to release.  If not provided we will determine the "
+             "version from the current value in the setup.py."
+    )
+    args = parser.parse_args()
+    args.setup_py = abspath(args.setup_py)
+
+    if not isfile(args.setup_py):
+        parser.error("%s does not exist" % args.setup_py)
+
+    setup_name = get_setup_keyword_value(args.setup_py, "name")
+    setup_version = get_setup_keyword_value(args.setup_py, "version")
+
+    print("From %s:" % args.setup_py)
+    print("  Package: %s" % setup_name)
+
+    if args.version is None:
+        print("  Version: %s" % setup_version)
+
+    answer = input_("Is this information correct? [Y/n] ")
+
+    if answer not in ("Y", "n"):
+        parser.error("Expected Y or n")
+
+    if answer == "n":
+        parser.error(
+            "Cannot continue, invalid parsed information.  Possible bug.")
+
+    release_package = setup_name
+    project_name = setup_name.replace(".", "-")
+    if args.version is None:
+        release_version = setup_version
+    else:
+        release_version = args.version
+
+    errors = []
+    if local_tag_exists(args.setup_py, release_version):
+        errors.append("Local tag %s already exists." % release_version)
+
+    if remote_tag_exists(project_name, release_version):
+        errors.append("Remote tag %s already exists." % release_version)
+
+
+    # Make sure we're not attempting to release a version less than the
+    # current release on PyPi
+    pypi_release = latest_pypi_release(release_package)
+    if pypi_release >= release_version:
+        errors.append(
+            "Release version is {release_version} but latest "
+            "PyPi release is {pypi_release}.".format(
+                release_version=release_version, pypi_release=pypi_release))
+
+    if errors:
+        parser.error(" ".join(errors))
+
+    create_tag(args.setup_py, release_version, dry_run=args.dry_run)
+    release_to_pypi(args.setup_py, dry_run=args.dry_run)
+
+
+
+
+

--- a/pyfarm/release/git.py
+++ b/pyfarm/release/git.py
@@ -1,0 +1,39 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Git
+===
+
+Module for running common git commands.
+"""
+
+import subprocess
+from os.path import dirname
+
+from pyfarm.release.utility import check_call
+
+def local_tag_exists(setup_py, tag):
+    output = subprocess.check_output(["git", "tag"], cwd=dirname(setup_py))
+    return tag in output.splitlines()
+
+
+def create_tag(setup_py, tag, dry_run=True):
+    print("Creating tag %s" % tag)
+    check_call(["git", "tag", tag], cwd=dirname(setup_py), dry_run=dry_run)
+    check_call(
+        ["git", "push", "--tags"], cwd=dirname(setup_py), dry_run=dry_run)
+

--- a/pyfarm/release/parse_setup.py
+++ b/pyfarm/release/parse_setup.py
@@ -1,0 +1,49 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Parse Setup
+===========
+
+Functions for parsing the setup.py file.
+"""
+
+import ast
+
+
+def iter_setup_keywords(setup_py):
+    """Generator which yields keywords inside of setup()"""
+    with open(setup_py, "rb") as setup:
+        parsed = ast.parse(setup.read())
+
+    for node in ast.walk(parsed):
+        if isinstance(node, ast.Call) and node.func.id == "setup":
+            break
+    else:
+        raise NameError("Failed to locate setup()")
+
+    for keyword in node.keywords:
+        yield keyword
+
+def get_setup_keyword_value(setup_py, keyword):
+    """
+    Returns the string value of the given keyword inside
+    of the setup() function in setup_py.
+    """
+    for node in iter_setup_keywords(setup_py):
+        if node.arg == keyword:
+            assert isinstance(node.value, ast.Str)
+            return node.value.s

--- a/pyfarm/release/remote.py
+++ b/pyfarm/release/remote.py
@@ -1,0 +1,58 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Remote
+======
+
+Utilities for parsing remote information such as PyPi and GitHub
+releases or tags.
+"""
+
+import requests
+
+SESSION = requests.Session()
+SESSION.headers.update(
+    {"Accept": "application/json", "Content-Type": "application/json"})
+PYPI_API = "https://pypi.python.org/pypi/{package}/json"
+GITHUB_API = "https://api.github.com/repos/pyfarm/{project}"
+
+def latest_pypi_release(package):
+    """
+    Returns the version number of the latest release in PyPi.
+    """
+    url = PYPI_API.format(package=package)
+    response = SESSION.get(url)
+    response.raise_for_status()
+    data = response.json()
+
+    for release, files in data["releases"].items():
+        for file_ in files:
+            if file_["md5_digest"] == data["urls"][0]["md5_digest"]:
+                return release
+
+def remote_tags(project):
+    """
+    Returns all remote tags for the given project
+    """
+    url = GITHUB_API.format(project=project) + "/git/refs/tags"
+    request = SESSION.get(url)
+    request.raise_for_status()
+    data = request.json()
+    return [entry["ref"].split("/")[-1] for entry in data]
+
+def remote_tag_exists(project, tag):
+    return tag in remote_tags(project)

--- a/pyfarm/release/utility.py
+++ b/pyfarm/release/utility.py
@@ -1,0 +1,32 @@
+# No shebang line, this module is meant to be imported
+#
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility
+=======
+
+General utilities used for releases.
+"""
+
+from __future__ import print_function
+
+import subprocess
+
+def check_call(cmd, dry_run=True, cwd=None):
+    if not dry_run:
+        subprocess.check_call(cmd, cwd=cwd)
+    else:
+        print("(dry-run) %s (cwd: %s)" % (" ".join(cmd), cwd))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+# Copyright 2015 Oliver Palmer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Until Twisted supports Python 3 we'll stick to Python 2.7.  That said
+# we should code as if we're supporting 3.0 now.
+import sys
+assert sys.version_info[0:2] == (2, 7), "Python 2.7 is required"
+
+from os.path import isfile
+from setuptools import setup
+
+if isfile("README.rst"):
+    with open("README.rst", "r") as readme:
+        long_description = readme.read()
+else:
+    long_description = ""
+
+
+setup(
+    name="pyfarm.build",
+    version="0.1.0",
+    packages=[
+        "pyfarm",
+        "pyfarm.release"
+    ],
+    namespace_packages=["pyfarm"],
+    entry_points={
+        "console_scripts": [
+            "pyfarm-release = pyfarm.release.entrypoints:release"]},
+    install_requires=["requests"],
+    url="https://github.com/pyfarm/pyfarm-build",
+    license="Apache v2.0",
+    author="Oliver Palmer",
+    author_email="development@pyfarm.net",
+    description="Helper library used for builds including production "
+                "of releases.",
+    long_description=long_description,
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Topic :: System :: Distributed Computing"])


### PR DESCRIPTION
The current release tools while functional are not very clean.  They also don't handle a couple of steps that would be nice to have:
- Create the release on GitHub and populate the description with closed issues and PRs
- Before producing the release generate the documentation, failing if there are changes as result unless it's a timestamp change or something (probably a regex to check for this will do).

After this PR closes we should be able to move the pyfarm repo out from under the pyfarm org.
